### PR TITLE
Revert ":optimization: 更改多图下载的方式, 缩短渲染时间: 继发 => 并发"

### DIFF
--- a/components/canvasdrawer/canvasdrawer.js
+++ b/components/canvasdrawer/canvasdrawer.js
@@ -57,7 +57,7 @@ Component({
           this.ctx.clearActions()
           this.ctx.save()
           this.getImageList(views)
-          this.downLoadImages()
+          this.downLoadImages(0)
         }
       }, 100)
     },
@@ -72,13 +72,20 @@ Component({
         imageList
       })
     },
-    downLoadImages () {
+    downLoadImages (index) {
       const { imageList, tempFileList } = this.data
-      Promise.all(imageList.map(url => this.getImageInfo(url))).then(files => {
-        tempFileList.push(...files)
-        this.setData({ tempFileList })
+      if (index < imageList.length) {
+        // console.log(imageList[index])
+        this.getImageInfo(imageList[index]).then(file => {
+          tempFileList.push(file)
+          this.setData({
+            tempFileList
+          })
+          this.downLoadImages(index + 1)
+        })
+      } else {
         this.startPainting()
-      });
+      }
     },
     startPainting () {
       const { tempFileList, painting: { views } } = this.data


### PR DESCRIPTION
Reverts kuckboy1994/mp_canvas_drawer#11

虽然可以加快请求速度，但是图片多的时候，并行的请求超过10个就不行了。或者可以尝试并行3-5个请求。