### PR TITLE
修复安卓生成图片错位bug

### DIFF
--- a/components/canvasdrawer/canvasdrawer.js
+++ b/components/canvasdrawer/canvasdrawer.js
@@ -113,7 +113,14 @@ Component({
       }
       this.ctx.draw(false, () => {
         wx.setStorageSync('canvasdrawer_pic_cache', this.cache)
-        this.saveImageToLocal()
+        if (/ios/i.test(system)) {
+          this.saveImageToLocal();
+        } else {
+          // 延迟保存图片，解决安卓生成图片错位bug。
+          setTimeout(() => {
+            this.saveImageToLocal()
+          }, 800);
+        }
       })
     },
     drawImage (params) {

--- a/components/canvasdrawer/canvasdrawer.js
+++ b/components/canvasdrawer/canvasdrawer.js
@@ -113,8 +113,9 @@ Component({
       }
       this.ctx.draw(false, () => {
         wx.setStorageSync('canvasdrawer_pic_cache', this.cache)
+        const system = wx.getSystemInfoSync().system
         if (/ios/i.test(system)) {
-          this.saveImageToLocal();
+          this.saveImageToLocal()
         } else {
           // 延迟保存图片，解决安卓生成图片错位bug。
           setTimeout(() => {


### PR DESCRIPTION
在安卓机生成图片保存时，文字会错位，延迟保存图片可解决此问题。